### PR TITLE
Swapped  and  for Laravel 5.3

### DIFF
--- a/src/LaraPlans/SubscriptionAbility.php
+++ b/src/LaraPlans/SubscriptionAbility.php
@@ -112,7 +112,7 @@ class SubscriptionAbility
     public function value($feature, $default = null)
     {
         $feature = $this->subscription->plan->features->first(function ($key, $value) use ($feature) {
-            return $value->code === $feature;
+            return $key->code === $feature;
         });
 
         if (is_null($feature))

--- a/src/LaraPlans/Traits/PlanSubscriber.php
+++ b/src/LaraPlans/Traits/PlanSubscriber.php
@@ -23,7 +23,7 @@ trait PlanSubscriber
             return $value->created_at->getTimestamp();
         })
         ->first(function ($key, $value) use ($name) {
-            return $value->name === $name;
+            return $key->name === $name;
         });
     }
 


### PR DESCRIPTION
It seems that for Laravel 5.3 the $key and $value needs to swap, else the package returns null from these methods.