### PR TITLE
Optimize subscription query.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /vendor
 /.phpintel
 composer.phar

--- a/src/LaraPlans/Models/PlanSubscription.php
+++ b/src/LaraPlans/Models/PlanSubscription.php
@@ -273,6 +273,18 @@ class PlanSubscription extends Model implements PlanSubscriptionInterface
     }
 
     /**
+     * Find subscription that's not ended.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeActive($query)
+    {
+        $now = Carbon::now();
+
+        $query->where('ends_at', '>', $now);
+    }
+
+    /**
      * Find subscription with an ending trial.
      *
      * @return \Illuminate\Database\Eloquent\Builder

--- a/src/LaraPlans/Traits/PlanSubscriber.php
+++ b/src/LaraPlans/Traits/PlanSubscriber.php
@@ -19,15 +19,11 @@ trait PlanSubscriber
      */
     public function subscription($name = 'default')
     {
-        $subscriptions = $this->subscriptions->sortByDesc(function ($value) {
-            return $value->created_at->getTimestamp();
-        });
-
-        foreach ($subscriptions as $key => $subscription) {
-            if ($subscription->name === $name) {
-                return $subscription;
-            }
-        }
+        return $this->subscriptions()
+            ->getQuery()
+            ->orderBy('created_at', 'desc')
+            ->where('name', $name)
+            ->first();
     }
 
     /**

--- a/src/LaraPlans/Traits/PlanSubscriber.php
+++ b/src/LaraPlans/Traits/PlanSubscriber.php
@@ -20,10 +20,9 @@ trait PlanSubscriber
     public function subscription($name = 'default')
     {
         return $this->subscriptions()
-            ->getQuery()
-            ->orderBy('created_at', 'desc')
             ->where('name', $name)
-            ->first();
+            ->orderBy('id', 'desc')
+            ->Active();
     }
 
     /**


### PR DESCRIPTION
```
        $subscriptions = $this->subscriptions->sortByDesc(function ($value) {
            return $value->created_at->getTimestamp();
        });

        foreach ($subscriptions as $key => $subscription) {
            if ($subscription->name === $name) {
                return $subscription;
            }
        }

```

The above retrieves all subscriptions, then iterates through them. This could be expensive depending on how many rows are on table. It would be much more efficient to perform as much operations in a query, and less with PHP. 