### PR TITLE
Update fire condition of SubscriptionPlanChanged

### DIFF
--- a/src/Laraplans/Models/PlanSubscription.php
+++ b/src/Laraplans/Models/PlanSubscription.php
@@ -95,7 +95,8 @@ class PlanSubscription extends Model implements PlanSubscriptionInterface
         });
 
         static::saved(function ($model) {
-            if ($model->getOriginal('plan_id') !== $model->plan_id) {
+            // check if there is a plan and it is changed
+            if ($model->getOriginal('plan_id') && $model->getOriginal('plan_id') !== $model->plan_id) {
                 event(new SubscriptionPlanChanged($model));
             }
         });


### PR DESCRIPTION
The SubscriptionPlanChanged event will be fired when change of existing subscription not also when creation of new subscription. Fixes issue #36 .