### PR TITLE
Update src\Laraplans\Models\PlanSubscription.php

### DIFF
--- a/src/Laraplans/Models/PlanSubscription.php
+++ b/src/Laraplans/Models/PlanSubscription.php
@@ -84,7 +84,7 @@ class PlanSubscription extends Model implements PlanSubscriptionInterface
         parent::boot();
 
         static::created(function ($model) {
-            Event::fire(new SubscriptionCreated($model));
+            Event::dispatch(new SubscriptionCreated($model));
         });
 
         static::saving(function ($model) {


### PR DESCRIPTION
At line 87, change Event::fire to Event::dispatch, because at Laravel 5.8, fire method is removed