### PR TITLE
Update Carboon usage

### DIFF
--- a/src/Laraplans/Models/PlanSubscription.php
+++ b/src/Laraplans/Models/PlanSubscription.php
@@ -202,7 +202,7 @@ class PlanSubscription extends Model implements PlanSubscriptionInterface
     {
         $endsAt = Carbon::instance($this->ends_at);
 
-        return Carbon::now()->gt($endsAt) or Carbon::now()->eq($endsAt);
+        return Carbon::now()->gte($endsAt);
     }
 
     /**

--- a/src/Laraplans/Models/PlanSubscriptionUsage.php
+++ b/src/Laraplans/Models/PlanSubscriptionUsage.php
@@ -71,6 +71,6 @@ class PlanSubscriptionUsage extends Model implements PlanSubscriptionUsageInterf
             return false;
         }
 
-        return Carbon::now()->gt($this->valid_until) or Carbon::now()->eq($this->valid_until);
+        return Carbon::now()->gte($this->valid_until);
     }
 }


### PR DESCRIPTION
`return Carbon::now()->gt($this->valid_until) or Carbon::now()->eq($this->valid_until);`

Carbon has gte function, Why not use it?
