### PR TITLE
Correct feature reset date generation (only after now)

### DIFF
--- a/src/Laraplans/Feature.php
+++ b/src/Laraplans/Feature.php
@@ -168,16 +168,23 @@ class Feature
      * Get feature's reset date.
      *
      * @param string $dateFrom
+     * @param boolean $afterNow
      * @return \Carbon\Carbon
+     * @throws Exceptions\InvalidIntervalException
      */
-    public function getResetDate($dateFrom = '')
+    public function getResetDate($dateFrom = '', $afterNow = false)
     {
         if (empty($dateFrom)) {
             $dateFrom = new Carbon;
         }
 
-        $period = new Period($this->resettable_interval, $this->resettable_count, $dateFrom);
+        // Generate end date (keep looping if we have to generate date after now)
+        do {
+            $period = new Period($this->resettable_interval, $this->resettable_count, $dateFrom);
 
-        return $period->getEndDate();
+            $endDate = $dateFrom = $period->getEndDate();
+        } while($afterNow && $endDate < Carbon::now());
+
+        return $endDate;
     }
 }

--- a/src/Laraplans/SubscriptionUsageManager.php
+++ b/src/Laraplans/SubscriptionUsageManager.php
@@ -45,11 +45,11 @@ class SubscriptionUsageManager
             // Set date from subscription creation date so
                 // the reset period match the period specified
                 // by the subscription's plan.
-                $usage->valid_until = $feature->getResetDate($this->subscription->created_at);
+                $usage->valid_until = $feature->getResetDate($this->subscription->created_at, true);
             } // If the usage record has been expired, let's assign
             // a new expiration date and reset the uses to zero.
             elseif ($usage->isExpired() === true) {
-                $usage->valid_until = $feature->getResetDate($usage->valid_until);
+                $usage->valid_until = $feature->getResetDate($usage->valid_until, true);
                 $usage->used = 0;
             }
         }

--- a/tests/Unit/FeatureTest.php
+++ b/tests/Unit/FeatureTest.php
@@ -2,6 +2,7 @@
 
 namespace Gerarodjbaez\Laraplans\Unit;
 
+use Illuminate\Support\Carbon;
 use Gerardojbaez\Laraplans\Feature;
 use Gerardojbaez\Laraplans\Tests\TestCase;
 use Gerardojbaez\Laraplans\Exceptions\InvalidPlanFeatureException;
@@ -50,6 +51,23 @@ class FeatureTest extends TestCase
         $feature->setResettableCount('1');
 
         $this->assertEquals('2016-09-16 17:14:16', (string)$feature->getResetDate('2016-08-16 17:14:16'));
+    }
+
+
+    /**
+     * Can generate feature reset date after now.
+     *
+     * @test
+     */
+    public function it_can_generate_feature_reset_after_now()
+    {
+        Carbon::setTestNow(Carbon::create(2016, 12, 21, 12));
+
+        $feature = new Feature('SAMPLE_DEFINED_FEATURE');
+        $feature->setResettableInterval('month');
+        $feature->setResettableCount('1');
+
+        $this->assertEquals('2017-01-16 17:14:16', (string) $feature->getResetDate('2016-08-16 17:14:16', true));
     }
 
     /**


### PR DESCRIPTION
Referring issue: #61 

Feature reset date should always be generated after today.